### PR TITLE
Key encryption and saving

### DIFF
--- a/src/desktop-client/client-404/constants.h
+++ b/src/desktop-client/client-404/constants.h
@@ -5,5 +5,8 @@
 
 constexpr qint64 MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024;  // 100 MB in bytes
 const QString CENTRAL_WIDGET_BACKGROUND = "background-color: rgb(231, 236, 239);";
+const QString keysPath = "/encryptedKeys_";
+const QString masterKeyPath = "/masterKey_";
+const QString binaryExtension = ".bin";
 
 #endif // CONSTANTS_H

--- a/src/desktop-client/client-404/encryptionhelper.cpp
+++ b/src/desktop-client/client-404/encryptionhelper.cpp
@@ -17,7 +17,7 @@ void EncryptionHelper::generateKey(unsigned char* key, size_t key_buffer_size) {
     if (key_buffer_size < crypto_aead_xchacha20poly1305_ietf_KEYBYTES) {
         throw invalid_argument("Key buffer too small");
     }
-    crypto_aead_xchacha20poly1305_ietf_keygen(key);
+    crypto_aead_xchacha20poly1305_ietf_keygen(key);//uses randombytes_buf() which sources entropy from the OS
 }
 
 void EncryptionHelper::generateNonce(unsigned char* nonce, size_t nonce_buffer_size) {

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -8,6 +8,9 @@
 #include <sodium.h>
 #include <QByteArray>
 #include <QString>
+#include <QCoreApplication>
+#include <iostream>
+using namespace std;
 
 bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64) {
     if (sodium_init() < 0) {
@@ -30,11 +33,13 @@ bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64) 
 
 bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString &privateKey, const QString &defaultName) {
     QJsonObject json;
+
     json["publicKey"] = publicKey;
     json["privateKey"] = privateKey;
 
     QJsonDocument doc(json);
     QByteArray jsonData = doc.toJson();
+
 
     QString fileName = QFileDialog::getSaveFileName(parent, "Save Keys", defaultName, "JSON Files (*.json);;All Files (*)");
     if (!fileName.isEmpty()) {
@@ -46,6 +51,29 @@ bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString
         } else {
             QMessageBox::warning(parent, "Error", "Failed to open file for writing.");
         }
+    }
+    return false;
+}
+
+
+bool encryptAndSaveKey(QWidget *parent, const QString &privateKey) {
+    QJsonObject json;
+    json["privateKey"] = privateKey;
+
+    QJsonDocument doc(json);
+    QByteArray jsonData = doc.toJson();
+
+
+    QString fileName = QCoreApplication::applicationDirPath() + "/encryptedKeys.json";
+
+
+    QFile file(fileName);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        file.write(jsonData);
+        file.close();
+        return true;
+    } else {
+        cout << "Error saving file" << endl;
     }
     return false;
 }

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -83,6 +83,7 @@ bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigne
         sodium_memzero(key, sizeof(key));
     }
 
+    // Prepare data: [ciphertext][nonce]
     ciphertext.insert(ciphertext.end(), nonce, nonce + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
 
     //Save encrypted private key file
@@ -136,15 +137,14 @@ bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, c
         0
         );
 
-    // Prepare data: [nonce][encryptedKey]
-    QByteArray outData(reinterpret_cast<const char*>(nonce), sizeof(nonce));
-    outData.append(reinterpret_cast<const char*>(encryptedKey.data()), static_cast<int>(encryptedKey.size()));
+    // Prepare data: [encryptedKey][nonce]
+    encryptedKey.insert(encryptedKey.end(), nonce, nonce + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
 
     // Save to file
     QString filePath = QCoreApplication::applicationDirPath() + masterKeyPath + username + binaryExtension;//masterKey.bin;
     QFile file(filePath);
     if (file.open(QIODevice::WriteOnly)) {
-        file.write(outData);
+        file.write(reinterpret_cast<const char*>(encryptedKey.data()), static_cast<qint64>(encryptedKey.size()));
         file.close();
         fill(encryptedKey.begin(), encryptedKey.end(), 0);
         encryptedKey.clear();

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -10,6 +10,9 @@
 #include <QString>
 #include <QCoreApplication>
 #include <iostream>
+#include <vector>
+#include <QByteArray>
+
 using namespace std;
 
 bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64) {
@@ -56,26 +59,102 @@ bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString
 }
 
 
-bool encryptAndSaveKey(QWidget *parent, const QString &privateKey) {
+bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigned char *derivedKey) {
     QJsonObject json;
     json["privateKey"] = privateKey;
 
     QJsonDocument doc(json);
     QByteArray jsonData = doc.toJson();
+    EncryptionHelper crypto;
+
+    unsigned char key[crypto_aead_xchacha20poly1305_ietf_KEYBYTES];
+    unsigned char nonce[crypto_aead_xchacha20poly1305_ietf_NPUBBYTES];
+
+    // Generate key and nonce
+    crypto.generateKey(key, crypto_aead_xchacha20poly1305_ietf_KEYBYTES);
+    crypto.generateNonce(nonce, crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+
+    //Encrypt private key file
+    vector<unsigned char> ciphertext;
+    bool success = false;
+    try {
+        ciphertext = encryptData(jsonData, key, nonce, crypto);
+    } catch (const std::exception &e) {
+        QMessageBox::critical(parent, "Encryption Error", e.what());
+        sodium_memzero(key, sizeof(key));
+    }
 
 
-    QString fileName = QCoreApplication::applicationDirPath() + "/encryptedKeys.json";
-
-
+    //Save encrypted private key file
+    QString fileName = QCoreApplication::applicationDirPath() + "/encryptedKeys.bin";
     QFile file(fileName);
-    if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
-        file.write(jsonData);
+    if (file.open(QIODevice::WriteOnly)) {
+        file.write(reinterpret_cast<const char*>(ciphertext.data()), static_cast<qint64>(ciphertext.size()));
+        file.close();
+    } else {
+        std::cout << "Error saving file" << std::endl;
+        return false;
+    }
+
+
+    //Encrypt and save master key
+    if(!encryptAndSaveMasterKey(key, crypto_aead_xchacha20poly1305_ietf_KEYBYTES, derivedKey, crypto)){
+        std::cout << "Error saving encrypted key file" << std::endl;
+        sodium_memzero(key, sizeof(key));
+        return false;
+    }
+
+    sodium_memzero(key, sizeof(key));
+    return true;
+}
+
+bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, const unsigned char *derivedKey, EncryptionHelper &crypto)
+{
+    // Generate nonce
+    unsigned char nonce[crypto_aead_xchacha20poly1305_ietf_NPUBBYTES];
+    crypto.generateNonce(nonce, sizeof(nonce));
+
+    // Encrypt the key
+    vector<unsigned char> encryptedKey = crypto.encrypt(
+        keyToEncrypt,
+        keyLen,
+        derivedKey,
+        nonce,
+        nullptr,
+        0
+        );
+
+    // Prepare data: [nonce][encryptedKey]
+    QByteArray outData(reinterpret_cast<const char*>(nonce), sizeof(nonce));
+    outData.append(reinterpret_cast<const char*>(encryptedKey.data()), static_cast<int>(encryptedKey.size()));
+
+    // Save to file
+    QString filePath = QCoreApplication::applicationDirPath() + "/masterKey.bin";
+    QFile file(filePath);
+    if (file.open(QIODevice::WriteOnly)) {
+        file.write(outData);
         file.close();
         return true;
     } else {
-        cout << "Error saving file" << endl;
+        return false;
     }
-    return false;
+}
+
+
+vector<unsigned char> encryptData(const QByteArray &plaintext, unsigned char *key, unsigned char *nonce, EncryptionHelper &crypto){
+
+    const unsigned char* plaintext_ptr = reinterpret_cast<const unsigned char*>(plaintext.constData());
+    unsigned long long plaintext_len = static_cast<unsigned long long>(plaintext.size());
+
+    // Encrypt with no metadata
+    return crypto.encrypt(
+        plaintext_ptr,
+        plaintext_len,
+        key,
+        nonce,
+        nullptr,
+        0
+        );
 }
 
 QString generateSalt(size_t length){
@@ -87,4 +166,17 @@ QString generateSalt(size_t length){
     QByteArray saltArray(reinterpret_cast<char*>(salt), SALT_LENGTH);
     QString saltBase64 = saltArray.toBase64();
     return saltBase64;
+}
+
+bool deriveKeyFromPassword(const string &password, const unsigned char *salt, unsigned char *key, size_t key_len) {
+    unsigned long long opslimit = crypto_pwhash_OPSLIMIT_INTERACTIVE;
+    size_t memlimit = crypto_pwhash_MEMLIMIT_INTERACTIVE;
+
+    return crypto_pwhash(
+               key, key_len,
+               password.c_str(), password.size(),
+               salt,
+               opslimit, memlimit,
+               crypto_pwhash_ALG_DEFAULT
+               ) == 0;
 }

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -10,6 +10,7 @@
 #include <QCoreApplication>
 #include <iostream>
 #include <vector>
+#include "constants.h"
 
 using namespace std;
 
@@ -57,7 +58,7 @@ bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString
 }
 
 
-bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigned char *derivedKey) {
+bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigned char *derivedKey, QString username) {
     QJsonObject json;
     json["privateKey"] = privateKey;
 
@@ -85,7 +86,7 @@ bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigne
     ciphertext.insert(ciphertext.end(), nonce, nonce + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
 
     //Save encrypted private key file
-    QString fileName = QCoreApplication::applicationDirPath() + "/encryptedKeys.bin";
+    QString fileName = QCoreApplication::applicationDirPath() + keysPath + username + binaryExtension; //encryptedKey_username.bin
     QFile file(fileName);
     if (file.open(QIODevice::WriteOnly)) {
         file.write(reinterpret_cast<const char*>(ciphertext.data()), static_cast<qint64>(ciphertext.size())); //convert to raw bytes
@@ -109,7 +110,7 @@ bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigne
 
 
     //Encrypt and save master key
-    if(!encryptAndSaveMasterKey(key, crypto_aead_xchacha20poly1305_ietf_KEYBYTES, derivedKey, crypto)){
+    if(!encryptAndSaveMasterKey(key, crypto_aead_xchacha20poly1305_ietf_KEYBYTES, derivedKey, crypto, username)){
         cout << "Error saving encrypted key file" << endl;
         sodium_memzero(key, sizeof(key));
         return false;
@@ -119,7 +120,7 @@ bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigne
     return true;
 }
 
-bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, const unsigned char *derivedKey, EncryptionHelper &crypto)
+bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, const unsigned char *derivedKey, EncryptionHelper &crypto, QString username)
 {
     // Generate nonce
     unsigned char nonce[crypto_aead_xchacha20poly1305_ietf_NPUBBYTES];
@@ -140,7 +141,7 @@ bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, c
     outData.append(reinterpret_cast<const char*>(encryptedKey.data()), static_cast<int>(encryptedKey.size()));
 
     // Save to file
-    QString filePath = QCoreApplication::applicationDirPath() + "/masterKey.bin";
+    QString filePath = QCoreApplication::applicationDirPath() + masterKeyPath + username + binaryExtension;//masterKey.bin;
     QFile file(filePath);
     if (file.open(QIODevice::WriteOnly)) {
         file.write(outData);

--- a/src/desktop-client/client-404/key_utils.h
+++ b/src/desktop-client/client-404/key_utils.h
@@ -9,8 +9,8 @@ using namespace std;
 
 bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64);
 bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString &privateKey, const QString &defaultName);
-bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigned char *derivedKey);
-bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, const unsigned char *derivedKey, EncryptionHelper &crypto);
+bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigned char *derivedKey, QString username);
+bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, const unsigned char *derivedKey, EncryptionHelper &crypto, QString username);
 vector<unsigned char> encryptData(const QByteArray &plaintext, unsigned char *key, unsigned char *nonce, EncryptionHelper &crypto);
 bool deriveKeyFromPassword(const string &password, const unsigned char *salt, unsigned char *key, size_t key_len);
 QString generateSalt(size_t length);

--- a/src/desktop-client/client-404/key_utils.h
+++ b/src/desktop-client/client-404/key_utils.h
@@ -7,6 +7,7 @@
 
 bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64);
 bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString &privateKey, const QString &defaultName);
+bool encryptAndSaveKey(QWidget *parent, const QString &privateKey);
 QString generateSalt(size_t length);
 
 #endif // KEY_UTILS_H

--- a/src/desktop-client/client-404/key_utils.h
+++ b/src/desktop-client/client-404/key_utils.h
@@ -3,11 +3,16 @@
 
 #include <QString>
 #include <QWidget>
+#include "encryptionhelper.h"
+using namespace std;
 
 
 bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64);
 bool saveKeysToJsonFile(QWidget *parent, const QString &publicKey, const QString &privateKey, const QString &defaultName);
-bool encryptAndSaveKey(QWidget *parent, const QString &privateKey);
+bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigned char *derivedKey);
+bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, const unsigned char *derivedKey, EncryptionHelper &crypto);
+vector<unsigned char> encryptData(const QByteArray &plaintext, unsigned char *key, unsigned char *nonce, EncryptionHelper &crypto);
+bool deriveKeyFromPassword(const string &password, const unsigned char *salt, unsigned char *key, size_t key_len);
 QString generateSalt(size_t length);
 
 #endif // KEY_UTILS_H

--- a/src/desktop-client/client-404/registerpage.cpp
+++ b/src/desktop-client/client-404/registerpage.cpp
@@ -92,7 +92,7 @@ void RegisterPage::onCreateAccountClicked()
 
 
 
-    QString salt = generateSalt(16);
+    QString salt = generateSalt(crypto_pwhash_SALTBYTES); //16 bytes
     QByteArray saltRaw = QByteArray::fromBase64(salt.toUtf8()); // decode to raw bytes
     unsigned char key[crypto_aead_xchacha20poly1305_ietf_KEYBYTES];
 

--- a/src/desktop-client/client-404/registerpage.cpp
+++ b/src/desktop-client/client-404/registerpage.cpp
@@ -91,6 +91,9 @@ void RegisterPage::onCreateAccountClicked()
     }
 
     saveKeysToJsonFile(this, pubKeyBase64, privKeyBase64, "keys.json");
+    encryptAndSaveKey(this, privKeyBase64);
+
+
 
     QString salt = generateSalt(16);
 

--- a/src/desktop-client/client-404/registerpage.cpp
+++ b/src/desktop-client/client-404/registerpage.cpp
@@ -104,7 +104,7 @@ void RegisterPage::onCreateAccountClicked()
     deriveKeyFromPassword(sPassword, reinterpret_cast<const unsigned char*>(saltRaw.constData()), key, sizeof(key));
 
     saveKeysToJsonFile(this, pubKeyBase64, privKeyBase64, "keys.json");
-    encryptAndSaveKey(this, privKeyBase64, key);
+    encryptAndSaveKey(this, privKeyBase64, key, accountName);
 
 
     //Debug prints

--- a/src/desktop-client/client-404/registerpage.cpp
+++ b/src/desktop-client/client-404/registerpage.cpp
@@ -90,17 +90,21 @@ void RegisterPage::onCreateAccountClicked()
         return;
     }
 
-    saveKeysToJsonFile(this, pubKeyBase64, privKeyBase64, "keys.json");
-    encryptAndSaveKey(this, privKeyBase64);
-
 
 
     QString salt = generateSalt(16);
+    QByteArray saltRaw = QByteArray::fromBase64(salt.toUtf8()); // decode to raw bytes
+    unsigned char key[crypto_aead_xchacha20poly1305_ietf_KEYBYTES];
 
     string sAccountName = accountName.toStdString();
     string sPassword = password.toStdString();
     string pubKey = password.toStdString();
     string sSalt = salt.toStdString();
+
+    deriveKeyFromPassword(sPassword, reinterpret_cast<const unsigned char*>(saltRaw.constData()), key, sizeof(key));
+
+    saveKeysToJsonFile(this, pubKeyBase64, privKeyBase64, "keys.json");
+    encryptAndSaveKey(this, privKeyBase64, key);
 
 
     //Debug prints


### PR DESCRIPTION
The private key is encrypted using the ChaCha20-Poly1305 algorithm (thanks to inspiration from @Kabidoye-17 implementation) and a truly random key (the master key), this ciphertext is saved into the projects build directory as a binary file. A second key is derived from the password using a deterministic password derivation function and a salt (which will be sent to the server). The master key is encrypted using the same algorithm and the derived key, and is stored in the projects build directory as a binary file. 

I am aware that this is the incorrect branch for this since this logic is done through the registration page, however by the time I realized this, I was half way through the implementation. 