### PR TITLE
Change sodium placement

### DIFF
--- a/src/desktop-client/client-404/encryptionhelper.cpp
+++ b/src/desktop-client/client-404/encryptionhelper.cpp
@@ -4,11 +4,7 @@
 
 using namespace std;
 
-EncryptionHelper::EncryptionHelper() {
-    if (sodium_init() < 0) {
-        throw runtime_error("Failed to initialize libsodium");
-    }
-}
+EncryptionHelper::EncryptionHelper() {}
 
 void EncryptionHelper::generateKey(unsigned char* key, size_t key_buffer_size) {
     if (key == nullptr) {

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -16,10 +16,6 @@
 using namespace std;
 
 bool generateSodiumKeyPair(QString &publicKeyBase64, QString &privateKeyBase64) {
-    if (sodium_init() < 0) {
-        // libsodium couldn't be initialized
-        return false;
-    }
 
     unsigned char publicKey[crypto_box_PUBLICKEYBYTES];
     unsigned char privateKey[crypto_box_SECRETKEYBYTES];

--- a/src/desktop-client/client-404/main.cpp
+++ b/src/desktop-client/client-404/main.cpp
@@ -4,6 +4,10 @@
 using namespace std;
 int main(int argc, char *argv[])
 {
+    // immediately shut down if this fails
+    if (sodium_init() < 0) {
+        throw runtime_error("Failed to initialize libsodium");
+    }
 
     QApplication a(argc, argv);
     MainWindow w;

--- a/src/desktop-client/client-404/verifypage.cpp
+++ b/src/desktop-client/client-404/verifypage.cpp
@@ -14,9 +14,6 @@ VerifyPage::VerifyPage(QWidget *parent)
     ,otherPublicKey(nullptr)
 {
     ui->setupUi(this);
-    if (sodium_init() < 0) {
-        QMessageBox::critical(this, "Error", "Failed to initialize libsodium");
-    }
 }
 
 VerifyPage::~VerifyPage()


### PR DESCRIPTION
- program's critical functions rely on sodium working so its best practice to fail fast if it doesn't work
- once it passes though, there is no need to check if multiple areas of the code