### PR TITLE
Save FEKs by UUID locally

### DIFF
--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -75,8 +75,8 @@ bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigne
 
     // Prepare data: [nonce][ciphertext]
     SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + ciphertext.size());
-    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copy nonce to beginning
-    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(),  combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);     // Move ciphertext data to avoid copying
+    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copies the nonce to the start of the buffer
+    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(),  combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES); // Copy the ciphertext to the buffer right after the nonce
 
     //Save encrypted private key file
     QString fileName = QCoreApplication::applicationDirPath() + keysPath + username + binaryExtension; //encryptedKey_username.bin
@@ -122,8 +122,8 @@ bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, c
 
     // Prepare data: [nonce][encryptedKey]
     SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + encryptedKey.size());
-    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());   // Copy nonce to beginning
-    std::copy(encryptedKey.data(), encryptedKey.data() + encryptedKey.size(), combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);  // Move encryptedKey data to avoid copying
+    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copies the nonce to the start of the buffer
+    std::copy(encryptedKey.data(), encryptedKey.data() + encryptedKey.size(), combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);  // Copy the ciphertext to the buffer right after the nonce
 
     // Save to file
     QString filePath = QCoreApplication::applicationDirPath() + masterKeyPath + username + binaryExtension;//masterKey.bin;

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -126,8 +126,6 @@ bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, c
     QString filePath = QCoreApplication::applicationDirPath() + masterKeyPath + username + binaryExtension;//masterKey.bin;
     bool (*saveFuncPtr)(const QString&, const SecureVector&) = saveFile; //function pointer
     bool success = saveFuncPtr(filePath, encryptedKey);
-    fill(encryptedKey.begin(), encryptedKey.end(), 0);
-    encryptedKey.clear();
     return success;
 }
 

--- a/src/desktop-client/client-404/key_utils.cpp
+++ b/src/desktop-client/client-404/key_utils.cpp
@@ -73,13 +73,15 @@ bool encryptAndSaveKey(QWidget *parent, const QString &privateKey, const unsigne
         QMessageBox::critical(parent, "Encryption Error", e.what());
     }
 
-    // Prepare data: [ciphertext][nonce]
-    ciphertext.insert(ciphertext.end(), nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+    // Prepare data: [nonce][ciphertext]
+    SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + ciphertext.size());
+    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copy nonce to beginning
+    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(),  combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);     // Move ciphertext data to avoid copying
 
     //Save encrypted private key file
     QString fileName = QCoreApplication::applicationDirPath() + keysPath + username + binaryExtension; //encryptedKey_username.bin
     bool (*saveFuncPtr)(const QString&, const SecureVector&) = saveFile; //function pointer
-    if (!saveFuncPtr(fileName, ciphertext)) {
+    if (!saveFuncPtr(fileName, combinedData)) {
         cout << "Error saving file" << endl;
         jsonData.fill(0);
         jsonData.clear();
@@ -118,14 +120,15 @@ bool encryptAndSaveMasterKey(const unsigned char *keyToEncrypt, size_t keyLen, c
         0
         );
 
-    // Prepare data: [encryptedKey][nonce]
-
-    encryptedKey.insert(encryptedKey.end(), nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+    // Prepare data: [nonce][encryptedKey]
+    SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + encryptedKey.size());
+    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());   // Copy nonce to beginning
+    std::copy(encryptedKey.data(), encryptedKey.data() + encryptedKey.size(), combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);  // Move encryptedKey data to avoid copying
 
     // Save to file
     QString filePath = QCoreApplication::applicationDirPath() + masterKeyPath + username + binaryExtension;//masterKey.bin;
     bool (*saveFuncPtr)(const QString&, const SecureVector&) = saveFile; //function pointer
-    bool success = saveFuncPtr(filePath, encryptedKey);
+    bool success = saveFuncPtr(filePath, combinedData);
     return success;
 }
 

--- a/src/desktop-client/client-404/loginsessionmanager.h
+++ b/src/desktop-client/client-404/loginsessionmanager.h
@@ -2,6 +2,7 @@
 #define LOGINSESSIONMANAGER_H
 
 #include <QString>
+#include "securevector.h"
 
 class LoginSessionManager {
 
@@ -9,8 +10,8 @@ public:
     static LoginSessionManager& getInstance();
 
     void setSession(const QString& username, const unsigned char* masterKey, size_t keyLength);
-    const QString& getUsername() const;
-    const unsigned char* getMasterKey() const;
+    const QString getUsername() const;
+    const SecureVector getMasterKey() const;
     void clearSession();
 
 private:
@@ -23,8 +24,7 @@ private:
     LoginSessionManager& operator=(LoginSessionManager&&) = delete;      // Disable move assignment: you cannot move-assign one instance to another.
 
     QString m_username;
-    unsigned char* m_masterKey;
-    size_t m_keyLength;
+    SecureVector m_masterKey;
 };
 
 #endif

--- a/src/desktop-client/client-404/securevector.cpp
+++ b/src/desktop-client/client-404/securevector.cpp
@@ -64,6 +64,10 @@ size_t SecureVector::size() const {
     return data_.size();
 }
 
+bool SecureVector::empty() const {
+    return data_.empty();
+}
+
 // Modify size and clear
 void SecureVector::resize(size_t newSize) {
     data_.resize(newSize);

--- a/src/desktop-client/client-404/securevector.cpp
+++ b/src/desktop-client/client-404/securevector.cpp
@@ -9,11 +9,31 @@ SecureVector::SecureVector() = default;
 
 SecureVector::SecureVector(size_t size) : data_(size) {}
 
-SecureVector::SecureVector(const  vector<unsigned char>& v) : data_(v) {}
+SecureVector::SecureVector(const SecureVector& other) : data_(other.data_.size()) {
+    copyFrom(other);
+}
 
 SecureVector::~SecureVector() {
     if (!data_.empty()) {
         sodium_memzero(data_.data(), data_.size());
+    }
+}
+
+SecureVector& SecureVector::operator=(const SecureVector& other) {
+    if (this != &other) {
+        // Clear existing data securely
+        clear();
+        
+        // Copy new data
+        data_.resize(other.data_.size());
+        copyFrom(other);
+    }
+    return *this;
+}
+
+void SecureVector::copyFrom(const SecureVector& other) {
+    if (!other.data_.empty()) {
+        std::copy(other.data_.begin(), other.data_.end(), data_.begin());
     }
 }
 

--- a/src/desktop-client/client-404/securevector.h
+++ b/src/desktop-client/client-404/securevector.h
@@ -8,12 +8,10 @@ class SecureVector {
 public:
     SecureVector();
     explicit SecureVector(size_t size);
-    SecureVector(const std::vector<unsigned char>& v);
+    SecureVector(const SecureVector& other);
     ~SecureVector();
 
-    // Disable copy constructor and assignment
-    SecureVector(const SecureVector&) = delete;
-    SecureVector& operator=(const SecureVector&) = delete;
+    SecureVector& operator=(const SecureVector& other);
 
     // Enable move constructor and assignment
     SecureVector(SecureVector&& other) noexcept;
@@ -36,6 +34,7 @@ public:
 
 private:
     std::vector<unsigned char> data_;
+    void copyFrom(const SecureVector& other);
 };
 
 #endif // SECUREVECTOR_H

--- a/src/desktop-client/client-404/securevector.h
+++ b/src/desktop-client/client-404/securevector.h
@@ -20,7 +20,8 @@ public:
     unsigned char* data();
     const unsigned char* data() const;
     size_t size() const;
-
+    bool empty() const;
+    
     void resize(size_t newSize);
     void clear();
 

--- a/src/desktop-client/client-404/uploadfilepage.cpp
+++ b/src/desktop-client/client-404/uploadfilepage.cpp
@@ -10,6 +10,8 @@
 #include "constants.h"
 #include "securevector.h"
 #include "securebufferutils.h"
+#include "loginsessionmanager.h"
+#include <QUuid>
 
 UploadFilePage::UploadFilePage(QWidget *parent)
     : BasePage(parent)
@@ -92,7 +94,7 @@ QByteArray UploadFilePage::formatFileMetadata(){
     return metadataBytes;
 }
 
-void UploadFilePage::encryptUploadedFile() {
+bool UploadFilePage::encryptUploadedFile() {
 
     EncryptionHelper crypto;
 
@@ -119,16 +121,225 @@ void UploadFilePage::encryptUploadedFile() {
             metadata_len
             );
 
+    // Prepare data: [nonce][ciphertext]
+    // This will be the data that is sent to the server
+    SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + ciphertext.size());
+
+    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copy nonce to beginning
+    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(),  combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);  // Move ciphertext data to avoid copying
+
+
+    // After sending to the server, we will recieve a uuid for the file as a string.
+    QString fileUuid = QUuid::createUuid().toString(QUuid::WithoutBraces);
+
+    return SaveKeyToLocalStorage(fileUuid, key.get(), crypto_aead_xchacha20poly1305_ietf_KEYBYTES); // expected key length that configured when creating the buffer
+
     } catch (const std::exception &e) {
         QMessageBox::critical(this, "Encryption Error", e.what());
+        return false;
     }
 }
+
+bool UploadFilePage::SaveKeyToLocalStorage(const QString &fileUuid, const unsigned char *key, size_t keyLen) {
+    // Validate inputs
+    if (!validateKeyParameters(key, keyLen)) {
+        return false;
+    }
+
+    // Get master key and validate it
+    const SecureVector masterKey = LoginSessionManager::getInstance().getMasterKey();
+    if (!validateMasterKey(masterKey)) {
+        return false;
+    }
+
+    // Get file path for user's key storage
+    const QString filepath = buildKeyStorageFilePath();
+    
+    // Read and decrypt key storage file
+    QByteArray jsonData;
+    if (!readAndDecryptKeyStorage(filepath, masterKey, jsonData)) {
+        return false;
+    }
+    
+    // Update JSON with new key
+    QByteArray updatedJsonData;
+    if (!addKeyToJsonStorage(jsonData, fileUuid, key, keyLen, updatedJsonData)) {
+        return false;
+    }
+    
+    // Encrypt and save updated storage
+    return encryptAndSaveKeyStorage(filepath, updatedJsonData, masterKey);
+}
+
+// Validate key parameters 
+bool UploadFilePage::validateKeyParameters(const unsigned char *key, size_t keyLen) {
+    if (key == nullptr || keyLen != crypto_aead_xchacha20poly1305_ietf_KEYBYTES) {
+        QMessageBox::warning(this, "Error",
+                             QString("Invalid file encryption key length: expected %1 bytes, got %2 bytes")
+                                 .arg(crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+                                 .arg(keyLen));
+        return false;
+    }
+    return true;
+}
+
+// Validate master key
+bool UploadFilePage::validateMasterKey(const SecureVector &masterKey) {
+    if (masterKey.empty() || masterKey.size() != crypto_aead_xchacha20poly1305_ietf_KEYBYTES) {
+        QMessageBox::warning(this, "Error",
+                             QString("Invalid master key length: expected %1 bytes, got %2 bytes")
+                                 .arg(crypto_aead_xchacha20poly1305_ietf_KEYBYTES)
+                                 .arg(masterKey.size()));
+        return false;
+    }
+    return true;
+}
+
+// Build the key storage file path
+QString UploadFilePage::buildKeyStorageFilePath() {
+    const QString username = LoginSessionManager::getInstance().getUsername();
+    return QCoreApplication::applicationDirPath() + keysPath + username + binaryExtension;
+}
+
+// Read and decrypt the key storage file
+bool UploadFilePage::readAndDecryptKeyStorage(const QString &filepath, 
+                                             const SecureVector &masterKey,
+                                             QByteArray &jsonData) {
+    // Check if file exists
+    if (!QFile::exists(filepath)) {
+        QMessageBox::warning(this, "Decryption Error", "Could not find encrypted keys file.");
+        return false;
+    }
+
+    // Read file data
+    QFile file(filepath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        QMessageBox::warning(this, "Decryption Error", 
+                            "Failed to open encrypted keys file: " + file.errorString());
+        return false;
+    }
+    const QByteArray fileData = file.readAll();
+    file.close();
+
+    // Validate data size
+    const int ciphertextSize = fileData.size() - crypto_aead_xchacha20poly1305_ietf_NPUBBYTES;
+    if (ciphertextSize <= 0) {
+        QMessageBox::warning(this, "Decryption Error", "Encrypted file is too small. It may be corrupted.");
+        return false;
+    }
+
+    // Extract components
+    SecureVector ciphertext(ciphertextSize);
+    auto nonce = make_secure_buffer<crypto_aead_xchacha20poly1305_ietf_NPUBBYTES>();
+    
+    std::copy(fileData.constData(), fileData.constData() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, nonce.get());
+    std::copy(fileData.constData() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, fileData.constData() + fileData.size(), ciphertext.begin());
+
+    // Decrypt data
+    EncryptionHelper crypto;
+    SecureVector plaintext;
+    try {
+        plaintext = crypto.decrypt(
+            ciphertext.data(),
+            ciphertextSize,
+            masterKey.data(),
+            nonce.get(),
+            nullptr,
+            0
+        );
+        
+        jsonData = QByteArray(reinterpret_cast<const char*>(plaintext.data()),
+                              static_cast<int>(plaintext.size()));
+
+        // DELETE BEFORE MERGE
+        QJsonDocument debugDoc = QJsonDocument::fromJson(jsonData);
+        if (debugDoc.isObject()) {
+            qDebug().noquote() << "Decrypted JSON Data:";
+            qDebug().noquote() << QJsonDocument(debugDoc).toJson(QJsonDocument::Indented);
+        } else {
+            qDebug() << "Decrypted JSON is not a valid object";
+        }
+        
+        return true;
+    } catch (const std::exception& e) {
+        ciphertext.clear();
+        QMessageBox::critical(this, "Decryption Error", 
+                             QString("Decryption failed: %1").arg(e.what()));
+        return false;
+    }
+}
+
+// Add a key to the JSON storage
+bool UploadFilePage::addKeyToJsonStorage(const QByteArray &jsonData, const QString &fileUuid, const unsigned char *key, size_t keyLen, QByteArray &updatedJsonData) {
+    // Parse JSON
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(jsonData, &parseError);
+    
+    if (parseError.error != QJsonParseError::NoError) {
+        QMessageBox::warning(this, "Error",
+                            QString("Failed to parse JSON: %1").arg(parseError.errorString()));
+        return false;
+    }
+
+    // Update JSON structure
+    QJsonObject json = doc.isObject() ? doc.object() : QJsonObject();
+    QJsonObject filesObject = json.contains("files") ? json["files"].toObject() : QJsonObject();
+    
+    // Convert key to base64
+    QByteArray keyBytes(reinterpret_cast<const char*>(key), keyLen);
+    filesObject[fileUuid] = QString(keyBytes.toBase64());
+    
+    json["files"] = filesObject;
+    doc.setObject(json);
+    
+    // Convert back to bytes
+    updatedJsonData = doc.toJson(QJsonDocument::Compact);
+    return true;
+}
+
+// Encrypt and save the updated key storage
+bool UploadFilePage::encryptAndSaveKeyStorage(const QString &filepath, const QByteArray &jsonData, const SecureVector &masterKey) {
+    EncryptionHelper crypto;
+    auto nonce = make_secure_buffer<crypto_aead_xchacha20poly1305_ietf_NPUBBYTES>();
+    crypto.generateNonce(nonce.get(), crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+    
+    // Encrypt data
+    SecureVector ciphertext = crypto.encrypt(
+        reinterpret_cast<const unsigned char*>(jsonData.constData()),
+        jsonData.size(),
+        masterKey.data(),
+        nonce.get(),
+        nullptr,
+        0
+    );
+    
+    // Prepare data for saving: [nonce][ciphertext]
+    SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + ciphertext.size());
+
+    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());
+    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(), combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+    
+    // Save file
+    QFile file(filepath);
+    if (!file.open(QIODevice::WriteOnly)) {
+        QMessageBox::warning(this, "Encryption Error", 
+                            "Failed to open file for writing: " + file.errorString());
+        return false;
+    }
+    
+    file.write(reinterpret_cast<const char*>(combinedData.data()), static_cast<qint64>(combinedData.size()));
+    file.close();
+    
+    return true;
+}
+
 
 
 void UploadFilePage::on_confirmButton_clicked(){
 
-    encryptUploadedFile();
-    QMessageBox::information(this, "Success", "File uploaded successfully!");
+   if (encryptUploadedFile()) {
+        QMessageBox::information(this, "Success", "File uploaded successfully!");
+   }
 
     // Clean up member variables and this->ui
     this->fileData.clear();

--- a/src/desktop-client/client-404/uploadfilepage.cpp
+++ b/src/desktop-client/client-404/uploadfilepage.cpp
@@ -262,7 +262,6 @@ bool UploadFilePage::readAndDecryptKeyStorage(const QString &filepath,
         
         return true;
     } catch (const std::exception& e) {
-        ciphertext.clear();
         QMessageBox::critical(this, "Decryption Error", 
                              QString("Decryption failed: %1").arg(e.what()));
         return false;

--- a/src/desktop-client/client-404/uploadfilepage.cpp
+++ b/src/desktop-client/client-404/uploadfilepage.cpp
@@ -13,6 +13,8 @@
 #include "loginsessionmanager.h"
 #include <QUuid>
 
+using namespace std;
+
 UploadFilePage::UploadFilePage(QWidget *parent)
     : BasePage(parent)
     , ui(new Ui::UploadFilePage)
@@ -125,8 +127,8 @@ bool UploadFilePage::encryptUploadedFile() {
     // This will be the data that is sent to the server
     SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + ciphertext.size());
 
-    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copy nonce to beginning
-    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(),  combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);  // Move ciphertext data to avoid copying
+    copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());    // Copy nonce to beginning
+    copy(ciphertext.data(), ciphertext.data() + ciphertext.size(),  combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);  // Move ciphertext data to avoid copying
 
 
     // After sending to the server, we will recieve a uuid for the file as a string.
@@ -134,7 +136,7 @@ bool UploadFilePage::encryptUploadedFile() {
 
     return SaveKeyToLocalStorage(fileUuid, key.get(), crypto_aead_xchacha20poly1305_ietf_KEYBYTES); // expected key length that configured when creating the buffer
 
-    } catch (const std::exception &e) {
+    } catch (const exception &e) {
         QMessageBox::critical(this, "Encryption Error", e.what());
         return false;
     }
@@ -232,8 +234,8 @@ bool UploadFilePage::readAndDecryptKeyStorage(const QString &filepath,
     SecureVector ciphertext(ciphertextSize);
     auto nonce = make_secure_buffer<crypto_aead_xchacha20poly1305_ietf_NPUBBYTES>();
     
-    std::copy(fileData.constData(), fileData.constData() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, nonce.get());
-    std::copy(fileData.constData() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, fileData.constData() + fileData.size(), ciphertext.begin());
+    copy(fileData.constData(), fileData.constData() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, nonce.get());
+    copy(fileData.constData() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, fileData.constData() + fileData.size(), ciphertext.begin());
 
     // Decrypt data
     EncryptionHelper crypto;
@@ -261,7 +263,7 @@ bool UploadFilePage::readAndDecryptKeyStorage(const QString &filepath,
         }
         
         return true;
-    } catch (const std::exception& e) {
+    } catch (const exception& e) {
         QMessageBox::critical(this, "Decryption Error", 
                              QString("Decryption failed: %1").arg(e.what()));
         return false;
@@ -315,8 +317,8 @@ bool UploadFilePage::encryptAndSaveKeyStorage(const QString &filepath, const QBy
     // Prepare data for saving: [nonce][ciphertext]
     SecureVector combinedData(crypto_aead_xchacha20poly1305_ietf_NPUBBYTES + ciphertext.size());
 
-    std::copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());
-    std::copy(ciphertext.data(), ciphertext.data() + ciphertext.size(), combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
+    copy(nonce.get(), nonce.get() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES, combinedData.begin());
+    copy(ciphertext.data(), ciphertext.data() + ciphertext.size(), combinedData.begin() + crypto_aead_xchacha20poly1305_ietf_NPUBBYTES);
     
     // Save file
     QFile file(filepath);

--- a/src/desktop-client/client-404/uploadfilepage.cpp
+++ b/src/desktop-client/client-404/uploadfilepage.cpp
@@ -252,15 +252,6 @@ bool UploadFilePage::readAndDecryptKeyStorage(const QString &filepath,
         
         jsonData = QByteArray(reinterpret_cast<const char*>(plaintext.data()),
                               static_cast<int>(plaintext.size()));
-
-        // DELETE BEFORE MERGE
-        QJsonDocument debugDoc = QJsonDocument::fromJson(jsonData);
-        if (debugDoc.isObject()) {
-            qDebug().noquote() << "Decrypted JSON Data:";
-            qDebug().noquote() << QJsonDocument(debugDoc).toJson(QJsonDocument::Indented);
-        } else {
-            qDebug() << "Decrypted JSON is not a valid object";
-        }
         
         return true;
     } catch (const exception& e) {

--- a/src/desktop-client/client-404/uploadfilepage.h
+++ b/src/desktop-client/client-404/uploadfilepage.h
@@ -3,6 +3,7 @@
 
 #include <QWidget>
 #include "basepage.h"
+#include "securevector.h"
 
 namespace Ui {
 class UploadFilePage;
@@ -30,8 +31,23 @@ private:
     qint64 fileSize;
     QByteArray fileData;
 
-    void encryptUploadedFile();
+    bool encryptUploadedFile();
     QByteArray formatFileMetadata();
+    bool SaveKeyToLocalStorage(const QString &fileUuid,const unsigned char *key, size_t keyLen);
+    bool validateKeyParameters(const unsigned char *key, size_t keyLen);
+    bool validateMasterKey(const SecureVector &masterKey);
+    QString buildKeyStorageFilePath();
+    bool readAndDecryptKeyStorage(const QString &filepath, 
+                                 const SecureVector &masterKey, 
+                                 QByteArray &jsonData);
+    bool addKeyToJsonStorage(const QByteArray &jsonData,
+                            const QString &fileUuid,
+                            const unsigned char *key,
+                            size_t keyLen,
+                            QByteArray &updatedJsonData);
+    bool encryptAndSaveKeyStorage(const QString &filepath,
+                                const QByteArray &jsonData,
+                                const SecureVector &masterKey);
 
     // Overridden methods from BasePage abstract class
     void initialisePageUi() override;


### PR DESCRIPTION
## Changes by commit
- first and last commit remove the redundant` .clear` calls as the cleanup on a `SecureVector `is handled automatically
- second commit was swapping the order of how our ciphertext and nonce were stored together. Originally `[ciphertext][nonce]` but changed to `[nonce][ciphertext]` to follow convention
- on third commit i realised that i was returning references and pointers to the members of the `LoginSessionManager `which was risky as if they changed accidentally, encryption and decryption is broken for the rest of the session. So I changed it to return copies. Was able to get in a copy constructor too in returning a `SecureVector `copy of the secure vector storing the original master key.
- fourth commit is all the logic to save the key by uuid locally (better to just read the code)

closes https://github.com/ElliceNels/blocksblocks/issues/23