### PR TITLE
[Libcurl] Sign Up

### DIFF
--- a/src/desktop-client/client-404/constants.h
+++ b/src/desktop-client/client-404/constants.h
@@ -32,8 +32,16 @@ const std::string ACCEPT_JSON = "Accept: application/json";
 const std::string AUTH_BEARER_PREFIX = "Authorization: Bearer ";
 const std::string REFRESH_TOKEN_HEADER = "X-Refresh-Token: ";
 
+// Default base URL for the server
+// PRODUCTION: Enforce HTTPS only
+// const std::string DEFAULT_BASE_URL = "https://gobbler.info/"; 
+
+// DEVELOPMENT: Allow both HTTP and HTTPS for local testing
+const std::string DEFAULT_BASE_URL = "http://127.0.0.1:5000"; 
+
 // API paths
 const std::string REFRESH_TOKEN_ENDPOINT = "/refresh";
+const std::string SIGN_UP_ENDPOINT = "/sign_up";
 
 //source: https://stackoverflow.com/questions/2053335/what-should-be-the-valid-characters-in-usernames
 constexpr string_view RESTRICTED_CHARS = R"(\/:*?"<>|'%;&=+$#@!~()[]{}., )";

--- a/src/desktop-client/client-404/core/loginsessionmanager.cpp
+++ b/src/desktop-client/client-404/core/loginsessionmanager.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <QString>
 #include "utils/securevector.h"
+#include "utils/request_utils.h"
 
 LoginSessionManager::LoginSessionManager() {}
 
@@ -33,6 +34,19 @@ const QString LoginSessionManager::getUsername() const {
 
 const SecureVector LoginSessionManager::getMasterKey() const {
     return SecureVector(this->m_masterKey);  // Return a SecureVector containing the master key
+}
+
+void LoginSessionManager::setTokens(const QString& accessToken, const QString& refreshToken) {
+    this->m_requestUtils.setBearerToken(accessToken.toStdString());
+    this->m_requestUtils.setRefreshToken(refreshToken.toStdString());
+}
+
+void LoginSessionManager::setBaseUrl(const QString& baseUrl) {
+    this->m_requestUtils.setBaseUrl(baseUrl.toStdString());
+}
+
+RequestUtils::Response LoginSessionManager::post(const std::string& url, const QJsonObject& data) {
+    return this->m_requestUtils.post(url, data);
 }
 
 void LoginSessionManager::clearSession() {

--- a/src/desktop-client/client-404/core/loginsessionmanager.h
+++ b/src/desktop-client/client-404/core/loginsessionmanager.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include "utils/securevector.h"
+#include "utils/request_utils.h"
 
 class LoginSessionManager {
 
@@ -12,6 +13,9 @@ public:
     void setSession(const QString& username, const unsigned char* masterKey, size_t keyLength);
     const QString getUsername() const;
     const SecureVector getMasterKey() const;
+    void setTokens(const QString& accessToken, const QString& refreshToken);
+    void setBaseUrl(const QString& baseUrl);
+    RequestUtils::Response post(const std::string& url, const QJsonObject& data = QJsonObject());
     void clearSession();
 
 private:
@@ -25,6 +29,7 @@ private:
 
     QString m_username;
     SecureVector m_masterKey;
+    RequestUtils m_requestUtils;
 };
 
 #endif

--- a/src/desktop-client/client-404/ui/registerpage.cpp
+++ b/src/desktop-client/client-404/ui/registerpage.cpp
@@ -154,6 +154,21 @@ void RegisterPage::onShowPasswordClicked()
     }
 }
 
+
+/**
+ * @brief Sends a sign-up request to the server with the provided user credentials and cryptographic data.
+ *
+ * This method constructs a JSON payload containing the username, hashed password, public key, and salt,
+ * then sends it to the server's sign-up endpoint. If the registration is successful, it extracts the
+ * access and refresh tokens from the server response and stores them in the LoginSessionManager.
+ * In case of failure, it displays an error message to the user.
+ *
+ * @param username The username to register.
+ * @param hashedPassword The hashed password of the user.
+ * @param publicKey The user's public key for cryptographic operations.
+ * @param salt The salt used for password hashing.
+ * @return true if registration is successful and tokens are saved; false otherwise.
+ */
 bool RegisterPage::sendSignUpRequest(const QString& username, const QString& hashedPassword, 
                                     const QString& publicKey, const QString& salt)
 {

--- a/src/desktop-client/client-404/ui/registerpage.h
+++ b/src/desktop-client/client-404/ui/registerpage.h
@@ -22,7 +22,6 @@ public:
 private slots:
     void onCreateAccountClicked();
     void onShowPasswordClicked();
-    void sendCredentials(string name, string email, string password, string publicKey, string salt);
 
 private:
     Ui::RegisterPage *ui;
@@ -30,6 +29,11 @@ private:
     // Overridden methods from BasePage abstract class
     void initialisePageUi() override;
     void setupConnections() override;
+
+    // Function to send sign-up request to the server
+    bool sendSignUpRequest(const QString& username, const QString& hashedPassword, 
+                                    const QString& publicKey, const QString& salt);
+
 
 signals:
     void goToLoginRequested();


### PR DESCRIPTION
- A follow on from the request_utils branch
- Since localhost which I'm testing doesn't have a domain name or cert, I decided to comment out those curl option under the label of production and leave development friendly ones. Once the server is ready, these will be swapped
- Same in the constants file, I have the commented out gobbler base url ready to go when the server is ready
- Added the request_utils object to the login sessionmanager as a safe space to handle tokens
- Also replaced the send credentials QT network request with this new libcurl approach


Proof
https://github.com/user-attachments/assets/5b7fa0af-5ae1-4d64-9489-5c594267c15d

