### PR TITLE
[Fix] Hash passwords on server side

### DIFF
--- a/src/server/models/tables.py
+++ b/src/server/models/tables.py
@@ -11,7 +11,7 @@ class Users(Base):
 
     id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String(50), unique=True, nullable=False)
-    password = Column(String(100), nullable=False)
+    password = Column(BLOB, nullable=False)
     salt = Column(BLOB, nullable=False)
     public_key = Column(String(191), nullable=False, unique=True)
     created_at = Column(DateTime, nullable=False)

--- a/src/server/requirements.txt
+++ b/src/server/requirements.txt
@@ -10,3 +10,4 @@ SQLAlchemy-Utils==0.41.1
 gunicorn==21.2.0
 pytest==8.3.5
 pytest-mock==3.14.0
+PyNaCl==1.5.0

--- a/src/server/routes/authentication_routes.py
+++ b/src/server/routes/authentication_routes.py
@@ -203,7 +203,6 @@ def get_current_user():
     Expected response:
     {
         "username": "<username>",
-        "password": "<password>",
         "public_key": "<public_key>",
         "salt": "<salt>",
         "created_at": "<created_at>",

--- a/src/server/routes/authentication_routes.py
+++ b/src/server/routes/authentication_routes.py
@@ -14,7 +14,7 @@ def login():
     Expected JSON payload:
     {
         "username": "<username>",
-        "hashed_password": "<hashed_password>",
+        "password": "<password>",
     }
 
     Expected response:
@@ -27,9 +27,9 @@ def login():
     data = request.get_json()
     logger.debug(f"Received login request for username: {data.get('username')}")
     username = data.get('username')
-    hash_password = data.get('hashed_password')
+    password = data.get('password')
 
-    return auth.login(username, hash_password)
+    return auth.login(username, password)
 
 @authentication_routes.route('/refresh', methods=['POST'])
 def refresh():
@@ -64,7 +64,7 @@ def sign_up():
     Expected JSON payload:
     {
         "username": "<username>",
-        "hashed_password": "<hashed_password>",
+        "password": "<password>",
         "public_key": "<public_key>",
         "salt": "<salt>"
     }
@@ -78,12 +78,12 @@ def sign_up():
     data = request.get_json()
     logger.debug(f"Received sign up request")
     username = data.get('username')
-    hash_password = data.get('hashed_password')
+    password = data.get('password')
     public_key = data.get('public_key')
     salt = data.get('salt')
     bytes_salt = salt.encode('utf-8') if isinstance(salt, str) else salt
 
-    return auth.sign_up(username, hash_password, public_key, bytes_salt)
+    return auth.sign_up(username, password, public_key, bytes_salt)
 
 @authentication_routes.route('/logout', methods=['POST'])
 def logout():
@@ -203,7 +203,7 @@ def get_current_user():
     Expected response:
     {
         "username": "<username>",
-        "password": "<hashed_password>",
+        "password": "<password>",
         "public_key": "<public_key>",
         "salt": "<salt>",
         "created_at": "<created_at>",

--- a/src/server/utils/auth.py
+++ b/src/server/utils/auth.py
@@ -34,7 +34,6 @@ def login(username: str, password: str) -> dict:
         return jsonify({"error": "User not found"}), 404
     
     # Cond 2: Password is incorrect for the given 
-    hashed_password = hash_password(password)
     if not verify_password(user.password, password):
         logger.warning(f"Login failed for user {username}: Invalid password")
         return jsonify({"error": "Invalid password"}), 401

--- a/src/server/utils/auth.py
+++ b/src/server/utils/auth.py
@@ -9,12 +9,12 @@ import base64
 
 logger = logging.getLogger(__name__)
 
-def login(username: str, password: bytes) -> dict:
+def login(username: str, password: str) -> dict:
     """Login route to authenticate users.
 
     Args:
         username (str): Username of the user.
-        password (bytes): Password of the user.
+        password (str): Password of the user.
 
     Returns:
         dict: response containing access and refresh tokens or error message.
@@ -253,11 +253,9 @@ def get_current_user() -> dict:
         return jsonify({"error": "User not found"}), 404
 
     user_info = {
-        "user_id": user.id,
         "username": user.username,
-        "password": user.password,
         "public_key": user.public_key,
-        "salt": user.salt,
+        "salt": base64.b64encode(user.salt).decode() if isinstance(user.salt, bytes) else user.salt,
         "created_at": user.created_at,
         "updated_at": user.updated_at
     }

--- a/tests/server/routes/test_authentication_routes.py
+++ b/tests/server/routes/test_authentication_routes.py
@@ -45,7 +45,7 @@ def test_user():
     unique_public_key = base64.b64encode(random_bytes).decode()
     return {
         "username": unique_username,
-        "hashed_password": "test_password",
+        "password": "test_password",
         "public_key": unique_public_key,
         "salt": "test_salt"
     }

--- a/tests/server/routes/test_authentication_routes.py
+++ b/tests/server/routes/test_authentication_routes.py
@@ -129,6 +129,13 @@ def test_get_public_key(client: FlaskClient, logged_in_user):
     assert "public_key" in response.json
     assert response.json["public_key"] == logged_in_user["user"]["public_key"]
 
+def test_get_current_user(client: FlaskClient, logged_in_user):
+    """Test getting current user information."""
+    headers = {"Authorization": f"Bearer {logged_in_user['access_token']}"}
+    response = client.get("/get_current_user", headers=headers)
+    assert response.status_code == 200
+    assert response.json["username"] == logged_in_user["user"]["username"]
+
 def test_db_tables_exist(setup_test_db):
     """Ensure tables exist after setup."""
     from server.models.tables import Users

--- a/tests/server/routes/test_file_routes.py
+++ b/tests/server/routes/test_file_routes.py
@@ -65,7 +65,7 @@ def test_user():
     unique_public_key = base64.b64encode(random_bytes).decode()
     return {
         "username": unique_username,
-        "hashed_password": "test_password",
+        "password": "test_password",
         "public_key": unique_public_key,
         "salt": "test_salt"
     }

--- a/tests/server/utils/test_auth.py
+++ b/tests/server/utils/test_auth.py
@@ -10,7 +10,7 @@ Some test explainations:
 import pytest
 from flask import Flask
 from unittest.mock import MagicMock
-from server.utils.auth import login, sign_up, change_password, delete_account, change_username
+from server.utils.auth import login, sign_up, change_password, delete_account, change_username, hash_password
 from server.models.tables import Users
 from server.app import create_app
 from server.utils.jwt import JWTError
@@ -52,14 +52,18 @@ def mock_session_ctx(mock_db):
     return Ctx()
 
 @pytest.mark.parametrize("username, password, expected_status", [
-    ("valid_user", b"correct_password", CODE_SUCCESS),  # Success
-    ("invalid_user", b"wrong_password", CODE_NOT_FOUND),  # User not found
-    (None, b"password", CODE_BAD_REQUEST),  # Missing username
+    ("valid_user", "correct_password", CODE_SUCCESS),  # Success
+    ("invalid_user", "wrong_password", CODE_NOT_FOUND),  # User not found
+    (None, "password", CODE_BAD_REQUEST),  # Missing username
     ("user", None, CODE_BAD_REQUEST),  # Missing password
-    ("user", b"wrong", CODE_UNAUTHORIZED)  # Invalid password
+    ("user", "wrong", CODE_UNAUTHORIZED)  # Invalid password
 ])
 def test_login_cases(username, password, expected_status, mock_db, app_ctx, mocker):
-    user = Users(username=username, password=b"correct_password") if expected_status in [CODE_SUCCESS, CODE_UNAUTHORIZED] else None
+    salt = b"salt"
+    if expected_status in [CODE_SUCCESS, CODE_UNAUTHORIZED]:
+        user = Users(username=username, password=hash_password("correct_password", salt), salt=salt)
+    else:
+        user = None
     mock_db.query().filter_by().first.return_value = user
     mocker.patch('server.utils.auth.get_session', return_value=mock_session_ctx(mock_db))
     response = login(username, password)
@@ -97,16 +101,16 @@ def test_sign_up_cases(username, password, public_key, salt, expected_status, mo
     "username, old_password, new_password, token, user_exists, token_error, expected_status, expected_error",
     [
         # Success
-        ("user1", b"old_pass", b"new_pass", 'token', True, None, CODE_SUCCESS, None),
+        ("user1", "old_pass", "new_pass", 'token', True, None, CODE_SUCCESS, None),
         # User not found
-        ("user2", b"wrong_pass", b"new_pass", 'token', False, None, CODE_NOT_FOUND, None),
+        ("user2", "wrong_pass", "new_pass", 'token', False, None, CODE_NOT_FOUND, None),
         # New password same as old
-        ("user3", b"same_pass", b"same_pass", 'token', True, None, CODE_BAD_REQUEST, None),
+        ("user3", "same_pass", "same_pass", 'token', True, None, CODE_BAD_REQUEST, None),
         # Missing required fields (username or token)
-        (None, b"old_pass", b"new_pass", "token", False, None, CODE_NOT_FOUND, None),
-        ("user4", "old_pass", b"new_pass", None, True, None, CODE_BAD_REQUEST, None),
+        (None, "old_pass", "new_pass", "token", False, None, CODE_NOT_FOUND, None),
+        ("user4", "old_pass", "new_pass", None, True, None, CODE_BAD_REQUEST, None),
         # Token error
-        ("user5", b"old_pass", b"new_pass", 'token', True, JWTError("err", CODE_UNAUTHORIZED), CODE_UNAUTHORIZED, "err"),
+        ("user5", "old_pass", "new_pass", 'token', True, JWTError("err", CODE_UNAUTHORIZED), CODE_UNAUTHORIZED, "err"),
     ]
 )
 def test_change_password_cases(
@@ -115,8 +119,9 @@ def test_change_password_cases(
 ):
     from server.utils.auth import change_password
     # Patch DB session
+    salt = b"salt"
     if user_exists:
-        user = Users(id=1, username=username, password=old_password)
+        user = Users(id=1, username=username, password=hash_password(old_password, salt), salt=salt)
         mock_db.query().filter_by().first.return_value = user
     else:
         mock_db.query().filter_by().first.return_value = None

--- a/tests/server/utils/test_auth.py
+++ b/tests/server/utils/test_auth.py
@@ -61,7 +61,7 @@ def mock_session_ctx(mock_db):
 def test_login_cases(username, password, expected_status, mock_db, app_ctx, mocker):
     salt = b"salt"
     if expected_status in [CODE_SUCCESS, CODE_UNAUTHORIZED]:
-        user = Users(username=username, password=hash_password("correct_password", salt), salt=salt)
+        user = Users(username=username, password=hash_password("correct_password"), salt=salt)
     else:
         user = None
     mock_db.query().filter_by().first.return_value = user
@@ -121,7 +121,7 @@ def test_change_password_cases(
     # Patch DB session
     salt = b"salt"
     if user_exists:
-        user = Users(id=1, username=username, password=hash_password(old_password, salt), salt=salt)
+        user = Users(id=1, username=username, password=hash_password(old_password), salt=salt)
         mock_db.query().filter_by().first.return_value = user
     else:
         mock_db.query().filter_by().first.return_value = None

--- a/tests/server/utils/test_db_connection.py
+++ b/tests/server/utils/test_db_connection.py
@@ -60,7 +60,7 @@ def create_user(session, username=None):
     logger.info(f"Creating test user: {username}")
     user = Users(
         username=username,
-        password=hash_password("password", salt=b"salt"),
+        password=hash_password("password"),
         salt=b"salt",
         public_key=f"public_key_{uuid.uuid4().hex[:8]}",
         created_at=datetime.now(UTC),
@@ -127,7 +127,7 @@ def test_update_user_password(db_session):
     logger.info("Testing password update")
     user = create_user(db_session)
     new_password = "new_password"
-    hashed_password = hash_password(new_password, salt=user.salt)
+    hashed_password = hash_password(new_password)
     user.password = hashed_password
     user.updated_at = datetime.now(UTC) + timedelta(seconds=1)
     db_session.commit()
@@ -248,7 +248,7 @@ def test_duplicate_public_keys_fail(db_session):
     public_key = "duplicate_key"
     user1 = Users(
         username="user1",
-        password=hash_password("password", salt=b"salt"),
+        password=hash_password("password"),
         salt=b"salt",
         public_key=public_key,
         created_at=datetime.now(UTC),
@@ -260,7 +260,7 @@ def test_duplicate_public_keys_fail(db_session):
     try:
         user2 = Users(
             username="user2",
-            password=hash_password("password", salt=b"salt"),
+            password=hash_password("password"),
             salt=b"salt",
             public_key=public_key,  # Same public key
             created_at=datetime.now(UTC),


### PR DESCRIPTION
>> - Expect plaintext passwords from requests
>> - Hash passwords before storage
>> - Update db to store password as bytes (hashed)
>> - Update tests to match (define salt for logins)

This needs to be updated with our chosen hashing algorithm
Migrations need to be applied