### PR TITLE
Add Secure Headers to Server Responses

### DIFF
--- a/src/server/app.py
+++ b/src/server/app.py
@@ -9,6 +9,7 @@ from server.routes.authentication_routes import authentication_routes as auth_bp
 from server.routes.permission_routes import permission_bp
 from server.routes.file_routes import files_bp
 from server.utils.db_setup import setup_db
+from server.utils.security import apply_security_headers
 from server.logger import setup_logger
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,10 @@ def create_app():
     app.register_blueprint(files_bp)
 
     logger.info('Blueprints registered')
+
+    @app.after_request
+    def add_security_headers(response):
+        return apply_security_headers(response)
 
     @app.route('/')
     def index():

--- a/src/server/utils/security.py
+++ b/src/server/utils/security.py
@@ -1,0 +1,24 @@
+from flask import Response
+
+def apply_security_headers(response: Response) -> Response:
+    """Apply security headers to all responses.
+    
+    Args:
+        response (Response): The Flask response object
+        
+    Returns:
+        Response: The modified response with security headers
+    """
+    response.headers['Content-Security-Policy'] = (
+        "default-src 'self'; "
+        "script-src 'self'; "
+        "object-src 'none'; "
+        "frame-ancestors 'none'; "
+        "base-uri 'self';"
+    )
+    response.headers['X-Frame-Options'] = 'DENY'
+    response.headers['X-XSS-Protection'] = '1; mode=block'
+    response.headers['X-Content-Type-Options'] = 'nosniff'
+    response.headers['Strict-Transport-Security'] = 'max-age=63072000; includeSubDomains; preload'
+    response.headers['Cache-Control'] = 'no-store, no-cache, must-revalidate, max-age=0'
+    return response 


### PR DESCRIPTION
 Add several headers to all server responses to address vunerabilities found in a zap scan. Verified that these are on all responses in postman
 
 - **Content Security Policy (CSP)**
  - Restricts resource loading to same origin
  - Prevents XSS and injection attacks
  - Configures strict script and object source policies

- **X-Frame-Options: DENY**
  - Prevents clickjacking attacks
  - Blocks any attempts to embed the application in iframes

- **X-XSS-Protection: 1; mode=block**
  - Enables browser's XSS filtering
  - Blocks the page if an XSS attack is detected

- **X-Content-Type-Options: nosniff**
  - Prevents MIME type sniffing
  - Reduces exposure to drive-by download attacks

- **Strict-Transport-Security**
  - Enforces HTTPS connections
  - Max age: 2 years
  - Includes subdomains
  - Preload enabled

- **Cache-Control**
  - Prevents caching of sensitive data
  - Ensures fresh content delivery
  - Configures proper cache validation